### PR TITLE
v1.4.02

### DIFF
--- a/Trip Planner/CHANGEDB.php
+++ b/Trip Planner/CHANGEDB.php
@@ -149,3 +149,7 @@ $sql[$count][0]="1.4.01";
 $sql[$count++][1]="
 ALTER TABLE tripPlannerRequestLog MODIFY COLUMN `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;end
 ";
+
+$sql[$count][0]="1.4.02";
+$sql[$count++][1]="
+";

--- a/Trip Planner/CHANGELOG.txt
+++ b/Trip Planner/CHANGELOG.txt
@@ -1,5 +1,12 @@
 CHANGELOG
 =========
+v1.4.02
+-------
+Fixed Approved trips in the past not appearing in Manage Trips
+Added row colours to the Manage Trips table
+Fixed a bug with dates not filling in the form when editing trips
+Enabled users with Manage Trips_full to edit any trip
+
 v1.4.01
 -------
 Fixed DB syntax error preventing proper install/update.

--- a/Trip Planner/manifest.php
+++ b/Trip Planner/manifest.php
@@ -23,7 +23,7 @@ $description = "A trip planner module for Gibbon.";
 $entryURL = "trips_manage.php";
 $type = "Additional";
 $category = "Learn";
-$version = "1.4.01";
+$version = "1.4.02";
 $author = "Ray Clark";
 $url = "https://github.com/GibbonEdu/module-tripPlanner";
 

--- a/Trip Planner/src/Domain/ApproverGateway.php
+++ b/Trip Planner/src/Domain/ApproverGateway.php
@@ -48,7 +48,7 @@ class ApproverGateway extends QueryableGateway
 
         $result = $this->runSelect($select);
         $users = array_reduce($result->fetchAll(), function ($group, $item) {
-            $group[$item['gibbonPersonID']] = Format::name($item['title'], $item['preferredName'], $item['surname'], 'Staff', false, true) . ' (' . $item['username'] . ')';
+            $group[$item['gibbonPersonID']] = Format::name($item['title'], $item['preferredName'], $item['surname'], 'Staff', true, true) . ' (' . $item['username'] . ')';
             return $group;
         }, array());
 

--- a/Trip Planner/trips_reportToday.php
+++ b/Trip Planner/trips_reportToday.php
@@ -29,7 +29,7 @@ $page->breadcrumbs->add(__('Today\'s Trips'));
 if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_reportToday.php')) {
     $page->addError(__('You do not have access to this action.'));
 } else {
-    $moduleName = $gibbon->session->get('module');
+    $moduleName = $session->get('module');
   
     $tripGateway = $container->get(TripGateway::class);
     $criteria = $tripGateway->newQueryCriteria(true)
@@ -41,7 +41,7 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_report
       ]))
       ->fromPOST();
 
-    $trips = $tripGateway->queryTrips($criteria);
+    $trips = $tripGateway->queryTrips($criteria, $session->get('gibbonSchoolYearID'));
 
     $table = DataTable::createPaginated('todaysTrips', $criteria);
     $table->setTitle(__("Today's Trips"));

--- a/Trip Planner/trips_requestApprove.php
+++ b/Trip Planner/trips_requestApprove.php
@@ -35,15 +35,15 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_manage
     $tripGateway = $container->get(TripGateway::class);
 
     $tripPlannerRequestID = $_GET['tripPlannerRequestID'] ?? '';
+    $trip = $tripGateway->getByID($tripPlannerRequestID);
 
-    if (empty($tripPlannerRequestID) || !$tripGateway->exists($tripPlannerRequestID)) {
+    if (empty($tripPlannerRequestID) || empty($trip)) {
         $page->addError(__('Invalid Trip Request Selected.'));
     } else {
         if (needsApproval($container, $gibbonPersonID, $tripPlannerRequestID)) {
             renderTrip($container, $tripPlannerRequestID, true);
-        } else {
+        } else if ($trip['status'] != 'Approved'){
             $page->addError(__('You do not have access to this action.'));
         }
     } 
 }   
-?>

--- a/Trip Planner/trips_submitRequest.php
+++ b/Trip Planner/trips_submitRequest.php
@@ -37,8 +37,8 @@ require_once __DIR__ . '/moduleFunctions.php';
 $edit = false;
 $prefix = 'Submit';
 
-$mode = $_GET['mode'] ?? '';
-$tripPlannerRequestID = $_GET['tripPlannerRequestID'] ?? '';
+$mode = $_REQUEST['mode'] ?? '';
+$tripPlannerRequestID = $_REQUEST['tripPlannerRequestID'] ?? '';
 
 //Check if a mode and id are given
 if (!empty($mode) && !empty($tripPlannerRequestID)) {
@@ -55,24 +55,25 @@ if (!empty($mode) && !empty($tripPlannerRequestID)) {
 
 $page->breadcrumbs->add(__($prefix . ' Trip Request'));
 
-$gibbonPersonID = $gibbon->session->get('gibbonPersonID');
+$gibbonPersonID = $session->get('gibbonPersonID');
+$highestAction = getHighestGroupedAction($guid, '/modules/Trip Planner/trips_manage.php', $connection2);
 
-if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submitRequest.php') || ($edit && $trip['creatorPersonID'] != $gibbonPersonID)) {
+if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submitRequest.php') || ($edit && $highestAction != 'Manage Trips_full' && $trip['creatorPersonID'] != $gibbonPersonID)) {
 //If the action isn't accesible, or in edit mode and the current user isn't the owner, throw error.
     $page->addError(__('You do not have access to this action.'));
 } else if ((isset($trip) && empty($trip)) || (!empty($mode) && !$edit)) {
     //If a trip is provided, but doesn't exit, Or the mode is set, but edit isn't enabled, throw error.
     $page->addError(__('Invalid Trip.'));
 } else {
-    $moduleName = $gibbon->session->get('module');
-    $gibbonSchoolYearID = $gibbon->session->get('gibbonSchoolYearID');
+    $moduleName = $session->get('module');
+    $gibbonSchoolYearID = $session->get('gibbonSchoolYearID');
 
     $settingGateway = $container->get(SettingGateway::class);
     $riskTemplateGateway = $container->get(RiskTemplateGateway::class);
 
     //Return Message
     if(!$edit && !empty($tripPlannerRequestID)) {
-        $page->return->setEditLink($gibbon->session->get('absoluteURL') . '/index.php?q=/modules/' . $moduleName . '/trips_requestView.php&tripPlannerRequestID=' . $tripPlannerRequestID);
+        $page->return->setEditLink($session->get('absoluteURL') . '/index.php?q=/modules/' . $moduleName . '/trips_requestView.php&tripPlannerRequestID=' . $tripPlannerRequestID);
     }
 
     //Templates
@@ -194,8 +195,8 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
     });
 
     //Submit Request Form
-    $form = Form::create('requestForm', $gibbon->session->get('absoluteURL') . '/modules/' . $moduleName . '/trips_submitRequestProcess.php');
-    $form->addHiddenValue('address', $gibbon->session->get('address'));
+    $form = Form::create('requestForm', $session->get('absoluteURL') . '/modules/' . $moduleName . '/trips_submitRequestProcess.php');
+    $form->addHiddenValue('address', $session->get('address'));
     $form->setTitle(__('Request'));
 
     //Basic Information Section
@@ -260,7 +261,7 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
     //TODO: Require atleast one entry
     //TODO: Date/Time overlap checking? Is that even possible???
     $row = $form->addRow();
-        $dateBlocks = $row->addCustomBlocks('dateTime', $gibbon->session)
+        $dateBlocks = $row->addCustomBlocks('dateTime', $session)
             ->fromTemplate($dateTimeBlock)
             ->settings([
                 'placeholder' => __('Date/Time Blocks will appear here...'),
@@ -301,7 +302,7 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
 
     //Custom Blocks
     $row = $form->addRow();
-        $costBlocks = $row->addCustomBlocks("cost", $gibbon->session)
+        $costBlocks = $row->addCustomBlocks("cost", $session)
             ->fromTemplate($costBlock)
             ->settings([
                 'placeholder' => __('Cost Blocks will appear here...'),
@@ -428,7 +429,7 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
                 $day['startTime'] = Format::time($day['startTime']);
                 $day['endTime'] = Format::time($day['endTime']);
             }
-
+            
             $dateBlocks->addBlock($day['tripPlannerRequestDaysID'], $day);
         }
     }
@@ -473,8 +474,8 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
             //Ensure that loaded dates have correct max and min dates.
             $('input[id^=startDate]').each(function() {
                 var endDate = $('#' + $(this).prop('id').replace('start', 'end'));
-                $(this).datepicker('option', {'maxDate': endDate.val()});
-                endDate.datepicker('option', {'minDate': $(this).val()});
+                // $(this).datepicker('option', {'maxDate': endDate.val()});
+                // endDate.datepicker('option', {'minDate': $(this).val()});
             });
 
             //Ensure that loaded endTimes are properly chained.
@@ -525,7 +526,7 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
         function addGroup(mode) {
             var data = $('#addStudentsByGroup').val();
             if(data != 'None') {
-                $('#addGroupDiv').load("<?php print $gibbon->session->get('absoluteURL') . '/modules/' . rawurlencode($moduleName) . '/trips_submitRequestAddGroupAjax.php'?>", 'data=' + data + '&mode=' + mode);
+                $('#addGroupDiv').load("<?php print $session->get('absoluteURL') . '/modules/' . rawurlencode($moduleName) . '/trips_submitRequestAddGroupAjax.php'?>", 'data=' + data + '&mode=' + mode);
             }
         }
     </script>

--- a/Trip Planner/trips_submitRequestProcess.php
+++ b/Trip Planner/trips_submitRequestProcess.php
@@ -21,8 +21,8 @@ $URL = $gibbon->session->get('absoluteURL') . '/index.php?q=/modules/' . $gibbon
 //Checking if editing mode should be enabled
 $edit = false;
 
-$mode = $_POST['mode'] ?? '';
-$tripPlannerRequestID = $_POST['tripPlannerRequestID'] ?? '';
+$mode = $_REQUEST['mode'] ?? '';
+$tripPlannerRequestID = $_REQUEST['tripPlannerRequestID'] ?? '';
 
 $tripGateway = $container->get(TripGateway::class);
 
@@ -38,19 +38,20 @@ if (!empty($mode) && !empty($tripPlannerRequestID)) {
 }
 
 $gibbonPersonID = $gibbon->session->get('gibbonPersonID');
+$highestAction = getHighestGroupedAction($guid, '/modules/Trip Planner/trips_manage.php', $connection2);
 
-if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submitRequest.php') || ($edit && $trip['creatorPersonID'] != $gibbonPersonID)) {
+if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submitRequest.php') || ($edit && $highestAction != 'Manage Trips_full' && $trip['creatorPersonID'] != $gibbonPersonID)) {
     //If the action isn't accesible, or in edit mode and the current user isn't the owner, throw error.
     $URL .= '/trips_manage.php&return=error0';
     header("Location: {$URL}");
     exit();
 } else if ((isset($trip) && empty($trip)) || (!empty($mode) && !$edit)) {
     //If a trip is provided, but doesn't exit, Or the mode is set, but edit isn't enabled, throw error.
-    $URL .= '/trips_submitRequest.php&return=error1';
+    $URL .= '/trips_submitRequest.php&return=error1&reason=a';
     header("Location: {$URL}");
     exit();
 } else {
-    $URL .= '/trips_submitRequest.php';
+    $URL .= '/trips_submitRequest.php&tripPlannerRequestID='.$tripPlannerRequestID.'&mode='.$mode;
 
     $gibbonSchoolYearID = $gibbon->session->get('gibbonSchoolYearID');
 
@@ -72,14 +73,16 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
         if (!empty($_POST[$key])) {
             $tripData[$key] = $_POST[$key];
         } else if ($required) {
-            $URL .= '&return=error1';
+            $URL .= '&return=error1&reason=b';
             header("Location: {$URL}");
             exit();
         }
     }
 
-    $tripData['creatorPersonID'] = $gibbonPersonID;
-    $tripData['gibbonSchoolYearID'] = $gibbonSchoolYearID;
+    if ($mode != 'edit') {
+        $tripData['creatorPersonID'] = $gibbonPersonID;
+        $tripData['gibbonSchoolYearID'] = $gibbonSchoolYearID;
+    }
     
     //Load Trip People
     $tripPeople = [];
@@ -91,7 +94,7 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
 
     //If no teachers have been added, throw an error.
     if (empty($tripPeople)) {
-        $URL .= '&return=error1';
+        $URL .= '&return=error1&reason=c';
         header("Location: {$URL}");
         exit();
     } 
@@ -114,7 +117,7 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
         $endDate = Format::createDateTime($day['endDate'], $dateFormat);
 
         if (!$startDate || !$endDate || $endDate < $startDate) {
-            $URL .= '&return=error1';
+            $URL .= '&return=error1&reason=d';
             header("Location: {$URL}");
             exit();
         } 
@@ -129,9 +132,9 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
             $endTime = DateTime::createFromFormat('H:i', $day['endTime']);
 
             if ($endTime <= $startTime) {
-                $URL .= '&return=error1';
-                header("Location: {$URL}");
-                exit();
+                $swapTime = $day['startTime'];
+                $day['startTime'] = $day['endTime'];
+                $day['endTime'] = $swapTime;
             }
 
         } else {
@@ -145,7 +148,7 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
 
     //If no days have been added, throw an error.
     if (empty($tripDays)) {
-        $URL .= '&return=error1';
+        $URL .= '&return=error1&reason=f';
         header("Location: {$URL}");
         exit();
     }
@@ -160,7 +163,7 @@ if (!isActionAccessible($guid, $connection2, '/modules/Trip Planner/trips_submit
         $cost = $_POST['cost'][$order];
 
         if (empty($cost['title']) || empty($cost['cost']) || $cost['cost'] < 0) {
-            $URL .= '&return=error1';
+            $URL .= '&return=error1&reason=g';
             header("Location: {$URL}");
             exit();
         }

--- a/Trip Planner/version.php
+++ b/Trip Planner/version.php
@@ -20,5 +20,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information
  */
-$moduleVersion = "1.4.01";
+$moduleVersion = "1.4.02";
 $coreVersion = '22.0.00';


### PR DESCRIPTION
Hello, this PR fixes some issues we ran into with the Manage Trips page not showing the list of trips as expected, and the edit trip action giving an error. I've updated some code and made some additional edits to simplify the logic for the Manage Trips filters, so that users with Manage Trips_full always see all trips, and other users only see their own trips:

- Fixed Approved trips in the past not appearing in Manage Trips
- Added row colours to the Manage Trips table
- Fixed a bug with dates not filling in the form when editing trips
- Enabled users with Manage Trips_full to edit any trip

One of the edits comments out the "Ensure that loaded dates have correct max and min dates" section in the Submit Request page, because it wasn't working as intended and was causing the dates to come up blank when editing a trip. If there's a way to fix it and keep that logic in the code, please update it, I wasn't familiar enough with the reason it was there to make that call.

Give a shout with any questions. Thanks!